### PR TITLE
adding config variable, docs and custom token storage functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,5 +68,15 @@ php skype.phar conversation:activity <to> <message>
         'fileTokenStoragePath' => '<yourOwnPath>',
    ]);
  ```
+   ```
+
+- You can also write your own TokenStorageInterface::class
+   ```
+  $client = new Client([
+       'clientId' => '<yourClientId>',
+       'clientSecret' => '<yourClientSecret>',
+       'tokenStorageClass' => DatabaseTokenStorage::class
+  ]);
+   ```
 
 More docs to come soon.

--- a/src/Skype/Client.php
+++ b/src/Skype/Client.php
@@ -57,7 +57,12 @@ class Client
     public function __construct(array $config = [], LoggerInterface $logger = null, OutputInterface $output = null, ClientInterface $client = null)
     {
         $this->config = new Config($config);
-        $this->tokenStorage = new FileTokenStorage($this->config->get('fileTokenStoragePath'));
+        try {
+            $class = $this->config->get('tokenStorageClass');
+            $this->tokenStorage = new $class();
+        } catch (SkypeException $exception) {
+            $this->tokenStorage = new FileTokenStorage($this->config->get('fileTokenStoragePath'));
+        }
         $this->logger = $logger;
         $this->output = $output;
 

--- a/src/Skype/Config.php
+++ b/src/Skype/Config.php
@@ -30,6 +30,10 @@ final class Config
     private $_fileTokenStoragePath;
 
     /**
+      * @var Token storage interface
+      */
+     private $_tokenStorageClass;
+    /**
      * Constructor
      *
      * @param  array          $data Array of parameters


### PR DESCRIPTION
Hey, thanks for this lib, worked like a charm so I took the time to make a pr with a functionality that I needed.
The client constructor now allows the user to write his own TokenStorageInterface, in my case, I needed to store the token in my db because I have ephemeral filesystem.

for some reaseon github screwed up the diff.
I only changed the constructor in the Client:

From:
-        $this->tokenStorage = new FileTokenStorage($this->config->get('fileTokenStoragePath'));
To:
```
try {
			$class = $this->config->get('tokenStorageClass');
			$this->tokenStorage = new $class();
		} catch (SkypeException $exception) {
			$this->tokenStorage = new FileTokenStorage($this->config->get('fileTokenStoragePath'));
		}
```